### PR TITLE
Peer Dashboard with preact+htm, js-ipfs 0.36.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Course C Materials
+
+## Prerequisites
+
+### Machine to run dashboard and go-ipfs
+
+TODO
+
+### Dedicated Wifi
+
+TODO
+
+### Configration
+
+#### js-ipfs-http-client
+
+TODO
+
+#### js-ipfs
+
+- customize bootstrap nodes and add one from LAN
+- (optional) add ws-star?
+
+#### go-ipfs configuration
+
+- `ipfs config`
+  - Remove friction by lifting CORS restrictions on API port: add `*` to `API.HTTPHeaders.Access-Control-Allow-Origin`
+  - Enable Websockets transport: add `/ip4/0.0.0.0/tcp/4042/ws` to `Addresses.Swarm`
+     - This enables us to use mentioned node as a bootstrap

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 	<!-- TODO: tachyons are good for prototyping, be can move final styles to external file when all is ready  -->
 	<link href="https://unpkg.com/tachyons@4.11.1/css/tachyons.min.css" rel="stylesheet">
 	<link href="https://unpkg.com/ipfs-css@0.12.0/ipfs.css" rel="stylesheet">
-
 	<title>Course C Exercise</title>
+
 </head>
 
 <body class="sans-serif">
@@ -22,80 +22,82 @@
 
 	<h2>References</h2>
 	<ul>
-		<li><a href="https://github.com/jimpick/course-c-static">GitHub</a></li>
-		<li><a href="https://codesandbox.io/s/7kzny7rj6q">Codesandbox</a></li>
-		<li><a href="https://github.com/ipfs/js-ipfs-http-client">js-ipfs-http-client</a></li>
-		<li><a href="https://github.com/ipfs/js-ipfs">js-ipfs</a></li>
+		<li><a href="https://github.com/jimpick/course-c-static">GitHub</a> / <a href="https://codesandbox.io/s/github/jimpick/course-c-static">Codesandbox</a></li>
+		<li><a href="https://github.com/ipfs/js-ipfs">js-ipfs</a> / <a href="https://github.com/ipfs/js-ipfs-http-client">js-ipfs-http-client</a></li>
 	</ul>
 
 	<hr class="mv3 bb bw1 b--black-10">
 
+	<section class="mv4">
 
-	<h2>Publishing Immutable Data (<code>/ipfs/</code>)</h2>
-	<h3>1. Add avatar image to IPFS</h3>
-	<form id='captureMedia'>
-		<input type='file' class="pointer" /><br />
-	</form>
-	<a id='addLink' target='_blank' href='' title="Open at HTTP Gateway"></a>
+		<h2>Publishing Immutable Data (<code class="navy">/ipfs/</code>)</h2>
+
+		<h3>1. Add avatar image to IPFS</h3>
+		<form id='addFileInput'>
+			<input type='file' class="pointer" /><br />
+		</form>
+		<a id='addCidOutput' target='_blank' href='' title="Open at HTTP Gateway"></a>
 
 
-	<h3>2. Load avatar from IPFS</h3>
-	<button id='get' class="pointer">Get the content</button>
-	<br />
-	<img id='data' class="h4 dib pa2"/>
+		<h3>2. Load avatar from IPFS</h3>
+		<button id='getButton' type="button" disabled>Get the content</button>
+		<br />
+		<img id='getImage' class="w4 dib pa2"/>
+
+	</section>
 
 	<hr class="mv3 bb bw1 b--black-10">
 
-	<h2>Updating Mutable Pointers (<code>/ipns/</code>)</h2>
-	<h3>3. Edit below and add to IPFS</h3>
-	<div>
-	<div>
+	<section class="mv4">
+
+		<h2>Updating Mutable Pointers (<code class="navy">/ipns/</code>)</h2>
+
+		<h3>3. Edit below and add to IPFS</h3>
 		<textarea id="editJson" name="editJson" rows="5" cols="80" class="monospace shadow-5 mb3">{
 name: 'CHANGE_ME',
 avatar: 'CHANGE_ME_TO_CID',
 about: 'CHANGE_ME'
 }</textarea><br/>
-		<button id='addJson'>Save to IPFS</button>
+		<button id="addJson" type="button">Save to IPFS</button>
 		<br />
 		<a id='jsonLink' target='_blank' href=''>
 		</a>
-	</div>
 
-	<h3>4. Publish a reference to the above snapshot at <code>/ipns/{peerId}</code></h3>
-	<div>
-		<button id='publish' disabled='true'>Publish to IPNS</button>
-		<br />
+		<h3>4. Publish a reference to the above snapshot at <code class="navy">/ipns/{peerId}</code></h3>
+		<button id='publish' type="button" disabled>Publish to IPNS</button><br />
 		<a id='publishLink'></a>
-	</div>
-	<h3>5. See the changes on the dashboard</h3>
 
+		<h3>5. See the changes on the dashboard</h3>
+
+</section>
+
+<!-- -->
 
 <script src="https://unpkg.com/ipfs-http-client@32.0.1/dist/index.min.js"></script>
 <script src="https://unpkg.com/ipfs@0.35.0/dist/index.min.js"></script>
 <script>
   const httpGateway = 'https://ipfs.io'
+
+  <!-- start js-ipfs in page context -->
 	const ipfs = new window.Ipfs()
 
-	ipfs.on('ready', () => {
-	  console.log('ready')
-	})
-	// const ipfs = window.IpfsHttpClient('localhost', '59685')
+	<!-- OR use js-ipfs-http-client and connect to remote API -->
+	// const ipfs = window.IpfsHttpClient('localhost', '5001')
+
 	const dom = {
-      form: document.querySelector('#captureMedia'),
-      addLink: document.querySelector('#addLink'),
-      get: document.querySelector('#get'),
-      data: document.querySelector('#data'),
+      addFileInput: document.querySelector('#addFileInput'),
+      addCidOutput: document.querySelector('#addCidOutput'),
+      getButton: document.querySelector('#getButton'),
+      getImage: document.querySelector('#getImage'),
 			editJson: document.querySelector('#editJson'),
 			addJson: document.querySelector('#addJson'),
 			jsonLink: document.querySelector('#jsonLink'),
       publish: document.querySelector('#publish'),
       publishLink: document.querySelector('#publishLink'),
 			peerBoard: document.querySelector('#peerBoard')
-  };
+  }
 
-  console.log(dom.form)
-
-  dom.form.addEventListener('change', (event)=> {
+  dom.addFileInput.addEventListener('change', (event)=> {
     event.stopPropagation()
     event.preventDefault()
     const file = event.target.files[0]
@@ -107,8 +109,9 @@ about: 'CHANGE_ME'
 	        console.log(response)
 	        const cid = response[0].hash
 	        console.log(cid)
-	        dom.addLink.href = `${httpGateway}/ipfs/${cid}`
-	        dom.addLink.textContent= cid
+	        dom.addCidOutput.href = `${httpGateway}/ipfs/${cid}`
+	        dom.addCidOutput.textContent= cid
+					dom.getButton.disabled = false
 	      }).catch((err) => {
 	        console.error(err)
 	      })
@@ -120,13 +123,13 @@ about: 'CHANGE_ME'
 		reader.readAsArrayBuffer(file)
   })
 
-  dom.get.addEventListener('click', event=> {
-    ipfs.cat(dom.addLink.textContent)
+  dom.getButton.addEventListener('click', event=> {
+    ipfs.cat(dom.addCidOutput.textContent)
     .then(data => {
 			// Instead of pointing at HTTP Gateway
 			// small images can be inlined using Data URLs (RFC 2397)
 			const img = data.toString('base64')
-      dom.data.src = "data:image/*;base64," + img;
+      dom.getImage.src = "data:image/*;base64," + img;
     })
     .catch(err => console.log(err))
   })
@@ -177,9 +180,10 @@ about: 'CHANGE_ME'
 		*/
 
 	async function refreshPeers() {
+		if (ipfs.isOnline && !ipfs.isOnline()) return []
 		try {
 			const peers = await ipfs.swarm.peers()
-			console.log('refreshPeers().peers', peers)
+			console.log('refreshPeers()', peers)
 			if (!peers) return []
 			return peers.map(info => {
 				return {

--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@ about: 'CHANGE_ME'
 <!-- -->
 
 <script src="https://unpkg.com/ipfs-http-client@32.0.1/dist/index.min.js"></script>
-<!-- TODO: replace with 0.36.1 as we need https://github.com/ipfs/js-ipfs/pull/2092 -->
-<script src="https://ipfs.io/ipfs/bafybeidpyx4mr5qhn4lwhef7f43w3eksmzs7knufhz6g35ey7vlxmk7y2a/index.min.js"></script>
+<script src="https://unpkg.com/ipfs@0.36.1/dist/index.min.js"></script>
 <script>
   const httpGateway = 'https://ipfs.io'
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <body class="sans-serif">
 	<header class="pv3 ph2 ph3-l bg-navy cf">
 		<img src="https://ipfs.io/images/ipfs-logo.svg" class="dib fr v-mid" style="height:50px">
-		<h1 class='aqua fw2 montserrat dib ma0 pv2 ph1 v-mid f3 lh-copy'> IPFS Camp 2019: Course C Exercise</h1>
+		<h1 class='aqua fw2 montserrat dib ma0 pv2 ph1 v-mid f3 lh-copy'> IPFS Camp 2019: Course C Exercise <strong>(DRAFT)</strong></h1>
 	</header>
 
 <div class="ph3-l mw9">
@@ -30,21 +30,19 @@
 
 	<hr class="mv3 bb bw1 b--black-10">
 
+
 	<h2>Publishing Immutable Data (<code>/ipfs/</code>)</h2>
 	<h3>1. Add avatar image to IPFS</h3>
 	<form id='captureMedia'>
-		<input type='file' /><br />
+		<input type='file' class="pointer" /><br />
 	</form>
-	<div>
-		<a id='addLink' target='_blank' href=''>
-		</a>
-	</div>
+	<a id='addLink' target='_blank' href='' title="Open at HTTP Gateway"></a>
+
+
 	<h3>2. Load avatar from IPFS</h3>
-	<div>
-		<button id='get'>Get the content</button>
-		<br />
-		<img id='data'/>
-	</div>
+	<button id='get' class="pointer">Get the content</button>
+	<br />
+	<img id='data' class="h4 dib pa2"/>
 
 	<hr class="mv3 bb bw1 b--black-10">
 
@@ -52,7 +50,7 @@
 	<h3>3. Edit below and add to IPFS</h3>
 	<div>
 	<div>
-		<textarea id="editJson" name="editJson" rows="5" cols="80" class="monospace">{
+		<textarea id="editJson" name="editJson" rows="5" cols="80" class="monospace shadow-5 mb3">{
 name: 'CHANGE_ME',
 avatar: 'CHANGE_ME_TO_CID',
 about: 'CHANGE_ME'
@@ -65,26 +63,17 @@ about: 'CHANGE_ME'
 
 	<h3>4. Publish a reference to the above snapshot at <code>/ipns/{peerId}</code></h3>
 	<div>
-		<button id='publish' disabled='true'>publish</button>
+		<button id='publish' disabled='true'>Publish to IPNS</button>
 		<br />
-		<b id='publishLink'></b>
+		<a id='publishLink'></a>
 	</div>
 	<h3>5. See the changes on the dashboard</h3>
 
 
-
-<hr class="mv3 bb bw1 b--black-10">
-
-
-	<!-- this should be moved to separate file and embedded via iframe -->
-	<h2>Peer Dashboard</h2>
-	<div id="peerBoard" class="flex flex-wrap justify-around ph3-l">
-	</div>
-<div>
-
-<script src="https://unpkg.com/ipfs-http-client/dist/index.min.js"></script>
-<script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
+<script src="https://unpkg.com/ipfs-http-client@32.0.1/dist/index.min.js"></script>
+<script src="https://unpkg.com/ipfs@0.35.0/dist/index.min.js"></script>
 <script>
+  const httpGateway = 'https://ipfs.io'
 	const ipfs = new window.Ipfs()
 
 	ipfs.on('ready', () => {
@@ -118,7 +107,7 @@ about: 'CHANGE_ME'
 	        console.log(response)
 	        const cid = response[0].hash
 	        console.log(cid)
-	        dom.addLink.href = 'https://ipfs.io/ipfs/'+cid
+	        dom.addLink.href = `${httpGateway}/ipfs/${cid}`
 	        dom.addLink.textContent= cid
 	      }).catch((err) => {
 	        console.error(err)
@@ -148,7 +137,7 @@ about: 'CHANGE_ME'
         console.log(response)
         const cid = response[0].hash
         console.log(cid)
-        dom.jsonLink.href = 'https://ipfs.io/ipfs/' + cid
+        dom.jsonLink.href = `${httpGateway}/ipfs/${cid}`
         dom.jsonLink.textContent = cid
 				dom.publish.disabled = false
       }).catch((err) => {
@@ -160,69 +149,90 @@ about: 'CHANGE_ME'
     dom.publishLink.textContent = 'Publishing...'
     ipfs.name.publish(dom.jsonLink.textContent)
     .then(({name, value}) => {
+			dom.publishLink.href = `${httpGateway}/ipns/${name}`
       dom.publishLink.textContent = `Published ${value} to /ipns/${name}`
     })
     .catch(err => console.log(err))
   })
 
+</script>
 
-  /* TODO: we need to move dashboard to separate filr and load it via iframe, otherwise template is too noisy */
 
-	const peerCardTemplate = `<article class="mw5 center bg-white br3 pa3 pa4-ns mv3 ba b--black-10" id="peer-PEER_ID">
-	<div>
-    <img src="https://robohash.org/PEER_ID.png?set=set4" class="br-100 h4 w4 dib ba b--black-05 pa2" title="PEER_ID">
-    <h1 class="f3 mb2 truncate" title="PEER_NAME">PEER_NAME</h1>
-		<h2 class="f5 fw4 charcoal-muted mt0 truncate" title="PEER_ADDR">PEER_ADDR</h2>
-		<hr class="mw3 bb bw1 b--black-10">
-	</div>
-	  <p class="lh-copy measure center f6 black-70">
-	    PEER_ABOUT
-	  </p>
-	</article>`
+<!-- PEER DASHBOARD -->
+<hr class="mv3 bb bw1 b--black-10">
+	<h2>Peer Dashboard</h2>
+	<div id="peerBoard"></div>
+<div>
 
-	function renderPeerBoard() {
-		/*
-		TODO:
-		 - show peers from course only:
-		   - filter out bootstrap nodes
-		   - show only peers form the same networks
-		   - (for course) show only peers from specific ipv4 network (match first octects of IP)
- 		 - Add green frame/checkbox to nodes that exposed { name, avatar, about } over IPNS
- 		*/
-		ipfs.swarm.peers()
-		.then((peers) => {
-			try {
-				if (!Array.isArray(peers)) throw peers
-				for (let peer of peers) {
-					renderPeer(peer)
-				}
-			} catch (err) {
-				console.error(err)
-			}
-		})
-	}
-	function renderPeer(peerInfo) {
-		/*
-		TODO: show PeerID if PEER_NAME is missing
+<script type="module">
+	import { html, Component, render } from 'https://unpkg.com/htm@2.1.1/preact/standalone.mjs';
+
+	/*
+	TODO:
+	 - show peers from course only:
+	   - filter out bootstrap nodes
+	   - show only peers form the same networks
+	   - (for course) show only peers from specific ipv4 network (match first octects of IP)
+		 - Add green frame/checkbox to nodes that exposed { name, avatar, about } over IPNS
 		*/
-		const peerAddr = peerInfo.addr.toString()
-		const peerId = peerInfo.peer.toJSON().id
-		const cardContent = peerCardTemplate.replace(/PEER_ID/g, peerId).replace(/PEER_ADDR/g, peerAddr)
-		const peerCard = document.querySelector('#peer-' + peerId)
-		if (peerCard != null) {
-			// console.log(`updating peerId`, peerId)
-			newPeerCard = peerCard.cloneNode(true)
-			const tmp = document.createElement('div')
-			tmp.innerHTML = cardContent
-			peerBoard.replaceChild(tmp.firstChild, peerCard)
-		} else {
-			// console.log(`adding new peerId`, peerId)
-			peerBoard.innerHTML += cardContent
+
+	async function refreshPeers() {
+		try {
+			const peers = await ipfs.swarm.peers()
+			console.log('refreshPeers().peers', peers)
+			if (!peers) return []
+			return peers.map(info => {
+				return {
+					id: info.peer.toJSON().id,
+					name: undefined, // TODO
+					avatar: undefined, // TODO
+					addr: info.addr.toString(),
+					about: undefined // TODO
+				}
+			})
+		} catch (err) {
+			console.error(err)
+			return []
 		}
 	}
-	// refresh dashboard
-	renderPeerBoard()
-	setInterval(renderPeerBoard, 3000);
+
+	class PeerDashboard extends Component {
+
+		async componentDidMount() {
+			const refreshData = async () => {
+				const peers = await refreshPeers()
+				this.setState({ peers })
+			}
+			refreshData()
+			this.timer = setInterval(refreshData, 3000)
+		}
+
+		componentWillUnmount() {
+			clearInterval(this.timer)
+		}
+
+		render({}, { peers = [] }) {
+			const peerCard = ({id, name, avatar, addr, about}) => {
+				const avatarUrl = avatar
+					? `${httpGateway}/ipfs/${avatar}`
+					: `https://robohash.org/${id}.png?set=set4`
+				return html`<div class="mw5 center bg-snow-muted br3 pa3 pa4-ns mv3 ba b--black-10 hover-bg-white">
+							<img src="${avatarUrl}" class="br-100 h4 w4 dib ba bg-white b--black-05 pa2 shadow-5" title="${id}" />
+							<h1 class="f3 mb2 truncate" title="${name || id}">${name || id}</h1>
+							<h2 class="f5 fw4 charcoal-muted mt0 truncate" title="${addr}">${addr}</h2>
+							<hr class="mw3 bb bw1 b--black-10" />
+						<p class="lh-copy measure center f6 black-70">${about || '(no about)'}</p>
+					</div>`
+			}
+			return html`
+				<section class="flex flex-wrap">
+				  ${peers.length ? '' : html`<p>Waiting for peer discovery..</p>`}
+					${peers.map(peerCard)}
+				</section>`
+		}
+	}
+
+	render(html`<${PeerDashboard} />`, document.getElementById('peerBoard'))
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,8 @@ about: 'CHANGE_ME'
 <!-- -->
 
 <script src="https://unpkg.com/ipfs-http-client@32.0.1/dist/index.min.js"></script>
-<script src="https://unpkg.com/ipfs@0.35.0/dist/index.min.js"></script>
+<!-- TODO: replace with 0.36.1 as we need https://github.com/ipfs/js-ipfs/pull/2092 -->
+<script src="https://ipfs.io/ipfs/bafybeidpyx4mr5qhn4lwhef7f43w3eksmzs7knufhz6g35ey7vlxmk7y2a/index.min.js"></script>
 <script>
   const httpGateway = 'https://ipfs.io'
 
@@ -97,65 +98,60 @@ about: 'CHANGE_ME'
 			peerBoard: document.querySelector('#peerBoard')
   }
 
-  dom.addFileInput.addEventListener('change', (event)=> {
+  dom.addFileInput.addEventListener('change', async event => {
     event.stopPropagation()
     event.preventDefault()
-    const file = event.target.files[0]
+		try {
+			const file = event.target.files[0]
+    	const response = await ipfs.add(file, { progress: (prog) => console.log(`received: ${prog}`) })
 
-		const addToIpfs = (reader) => {
-			const buffer = window.IpfsHttpClient.Buffer.from(reader.result)
-	    ipfs.add(buffer, { progress: (prog) => console.log(`received: ${prog}`) })
-	      .then((response) => {
-	        console.log(response)
-	        const cid = response[0].hash
-	        console.log(cid)
-	        dom.addCidOutput.href = `${httpGateway}/ipfs/${cid}`
-	        dom.addCidOutput.textContent= cid
-					dom.getButton.disabled = false
-	      }).catch((err) => {
-	        console.error(err)
-	      })
-		}
+			console.log('ipfs.add response', response)
 
-		// TODO: remove need for reading from reader and pass file object to ipfs.add directly
-		const reader = new window.FileReader()
-		reader.onloadend = () => addToIpfs(reader)
-		reader.readAsArrayBuffer(file)
+      const cid = response[0].hash
+
+      dom.addCidOutput.href = `${httpGateway}/ipfs/${cid}`
+      dom.addCidOutput.textContent = cid
+			dom.getButton.disabled = false
+    } catch(err) {
+      console.error(err)
+    }
   })
 
-  dom.getButton.addEventListener('click', event=> {
-    ipfs.cat(dom.addCidOutput.textContent)
-    .then(data => {
+  dom.getButton.addEventListener('click', async event => {
+		try {
+    	const data = await ipfs.cat(dom.addCidOutput.textContent)
 			// Instead of pointing at HTTP Gateway
 			// small images can be inlined using Data URLs (RFC 2397)
 			const img = data.toString('base64')
-      dom.getImage.src = "data:image/*;base64," + img;
-    })
-    .catch(err => console.log(err))
+      dom.getImage.src = "data:image/*;base64," + img
+    } catch(err) {
+			console.log(err)
+		}
   })
 
-  dom.addJson.addEventListener('click', event=> {
-    ipfs.add(window.IpfsHttpClient.Buffer.from(dom.editJson.value), { progress: (prog) => console.log(`received: ${prog}`) })
-      .then((response) => {
-        console.log(response)
-        const cid = response[0].hash
-        console.log(cid)
-        dom.jsonLink.href = `${httpGateway}/ipfs/${cid}`
-        dom.jsonLink.textContent = cid
-				dom.publish.disabled = false
-      }).catch((err) => {
-        console.error(err)
-      })
+  dom.addJson.addEventListener('click', async event => {
+		try {
+			const json = window.IpfsHttpClient.Buffer.from(dom.editJson.value)
+	    const response = await ipfs.add(json, { progress: (prog) => console.log(`received: ${prog}`) })
+	    const cid = response[0].hash
+			console.log('ipfs.add response', response)
+	    dom.jsonLink.href = `${httpGateway}/ipfs/${cid}`
+	    dom.jsonLink.textContent = cid
+			dom.publish.disabled = false
+    } catch (err) {
+      console.error(err)
+    }
   })
 
-  dom.publish.addEventListener('click', event=> {
-    dom.publishLink.textContent = 'Publishing...'
-    ipfs.name.publish(dom.jsonLink.textContent)
-    .then(({name, value}) => {
+  dom.publish.addEventListener('click', async event => {
+		try {
+	    dom.publishLink.textContent = 'Publishing...'
+	    const {name, value} = await ipfs.name.publish(dom.jsonLink.textContent)
 			dom.publishLink.href = `${httpGateway}/ipns/${name}`
       dom.publishLink.textContent = `Published ${value} to /ipns/${name}`
-    })
-    .catch(err => console.log(err))
+    } catch(err) {
+			console.log(err)
+		}
   })
 
 </script>
@@ -220,11 +216,12 @@ about: 'CHANGE_ME'
 				const avatarUrl = avatar
 					? `${httpGateway}/ipfs/${avatar}`
 					: `https://robohash.org/${id}.png?set=set4`
-				return html`<div class="mw5 center bg-snow-muted br3 pa3 pa4-ns mv3 ba b--black-10 hover-bg-white">
-							<img src="${avatarUrl}" class="br-100 h4 w4 dib ba bg-white b--black-05 pa2 shadow-5" title="${id}" />
+				const avatarStyle = `background-image: url('${avatarUrl}');background-size: cover;`
+				return html`<div class="mw5 center bg-snow-muted br3 pa3 pa4-ns mv3 ba b--black-20 hover-bg-white">
+							<div style="${avatarStyle}" class="br-100 h4 w4 shadow-5" title="${id}"></div>
 							<h1 class="f3 mb2 truncate" title="${name || id}">${name || id}</h1>
 							<h2 class="f5 fw4 charcoal-muted mt0 truncate" title="${addr}">${addr}</h2>
-							<hr class="mw3 bb bw1 b--black-10" />
+							<hr class="dbi mw4 bb bw1 b--black-10" />
 						<p class="lh-copy measure center f6 black-70">${about || '(no about)'}</p>
 					</div>`
 			}


### PR DESCRIPTION
This PR is converting mock from https://bafkreifckdqknntpdhlufirtqr2degx4fzsclgae5k4vmkbootkvndllhu.ipfs.dweb.link/
into a working dashboard 

**PREVIEW**: https://bafkreibujrpkwwsjf5vwhsi3k425d47z5jvjlb2qaohunf7zxmv4weuqsq.ipfs.dweb.link

DONE:

- peer dashboard built with [preact/htm (ES6 Module)](https://github.com/developit/htm),
- switched to js-ipfs 0.36.1
  - it ships with support for passing DOM File object to `ipfs.add`  and fix for https://github.com/ipfs/js-ipfs/issues/2090
- swapped promises with async/await to make code easier to read

TODO (separate PR?):
- resolve IPNS for every peer and load JSON data if present